### PR TITLE
PB-39283 Don't use default time based expiry

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/sdk/examples/BasicPackageCreationExample.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/examples/BasicPackageCreationExample.java
@@ -1,7 +1,9 @@
 package com.silanis.esl.sdk.examples;
 
 import com.silanis.esl.sdk.DocumentPackage;
+import com.silanis.esl.sdk.DocumentPackageSettings;
 import com.silanis.esl.sdk.DocumentType;
+import com.silanis.esl.sdk.builder.DocumentPackageSettingsBuilder;
 import com.silanis.esl.sdk.builder.FieldBuilder;
 
 import java.util.Date;
@@ -51,9 +53,14 @@ public class BasicPackageCreationExample extends SDKSample {
         documentInputStream1 = this.getClass().getClassLoader().getResourceAsStream("document_with_text_tag_and_form_field.pdf");
         email2 = "CapitalLetters@email.com";
 
+        DocumentPackageSettings packageSettings = DocumentPackageSettingsBuilder.newDocumentPackageSettings()
+                .withoutDefaultTimeBasedExpiry()
+                .build();
+        
         DocumentPackage superDuperPackage = newPackageNamed(getPackageName())
                 .withTimezoneId(PACKAGE_TIMEZONE_ID)
                 .describedAs(PACKAGE_DESC)
+                .withSettings(packageSettings)
                 .expiresAt(PACKAGE_EXPIRY)
                 .withEmailMessage(PACKAGE_EMAIL_MSG)
                 .withSigner(newSignerWithEmail(email1)

--- a/sdk/src/main/java/com/silanis/esl/sdk/examples/UpdatePackageExample.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/examples/UpdatePackageExample.java
@@ -106,6 +106,7 @@ public class UpdatePackageExample extends SDKSample {
                  .withOptOutReason(OLD_OPT_OUT_REASON_3)
                  .withWatermark()
                  .withCeremonyLayoutSettings(layoutSettingsToCreate)
+                 .withoutDefaultTimeBasedExpiry()
                  .build();
 
         packageToCreate = PackageBuilder.newPackageNamed(OLD_PACKAGE_NAME)
@@ -165,6 +166,7 @@ public class UpdatePackageExample extends SDKSample {
             .withOptOutReason(NEW_OPT_OUT_REASON_3)
             .withoutWatermark()
             .withCeremonyLayoutSettings(layoutSettingsToUpdate)
+            .withoutDefaultTimeBasedExpiry()
             .build();
 
         packageToUpdate = PackageBuilder.newPackageNamed(NEW_PACKAGE_NAME)


### PR DESCRIPTION
When setting package expiry as a date it's important to set "defaultTimeBasedExpirty" to false
so that the date won't get overwritten with the default "number of days" based value.