### PR TITLE
PB-63838 "from" attribute is removed from CompleteSummaryOptions in SigningUiOptions - complete fix in future sprints

### DIFF
--- a/tester/src/test/java/com/silanis/esl/sdk/examples/SigningStyleExampleTest.java
+++ b/tester/src/test/java/com/silanis/esl/sdk/examples/SigningStyleExampleTest.java
@@ -40,13 +40,10 @@ public class SigningStyleExampleTest {
         assertThat(example.updatedSigningLogos, hasSize(2));
         assertThat(example.removedSigningLogos, hasSize(0));
 
-        assertTrue("'from' in CompleteSummaryOptions should be true by default", example.defaultSigningUiOptions.getCompleteSummaryOptions().getFrom());
         assertTrue("'title' in OverviewOptions should be true by default", example.defaultSigningUiOptions.getOverviewOptions().getTitle());
 
-        assertFalse("'from' in CompleteSummaryOptions should be set as false", example.patchedSigningUiOptions.getCompleteSummaryOptions().getFrom());
         assertFalse("'title' in OverviewOptions should be set as false", example.patchedSigningUiOptions.getOverviewOptions().getTitle());
 
-        assertTrue("'from' in CompleteSummaryOptions should be true", example.defaultSigningUiOptions.getCompleteSummaryOptions().getFrom());
         assertTrue("'title' in OverviewOptions should be true", example.defaultSigningUiOptions.getOverviewOptions().getTitle());
 
 


### PR DESCRIPTION
PB-63838 "from" attribute is removed from CompleteSummaryOptions in SigningUiOptions. 
SigningStyleExampleTest failed because of this. 
SDKs will be updated properly in future releases.