### PR TITLE
PB-101291 Fix 2 bugs when create a properties file without baseURL an…

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/sdk/builder/EslClientBuilder.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/builder/EslClientBuilder.java
@@ -78,7 +78,7 @@ public class EslClientBuilder {
                 .withClientId(props.getProperty("api.oauth.clientID"))
                 .withClientSecret(props.getProperty("api.oauth.clientSecret"))
                 .withScope(props.getProperty("api.oauth.scope"))
-                .withBaseURL(props.getProperty("baseURL"))
+                .withBaseURL(props.getProperty("baseURL", props.getProperty("webpage.url")))
                 .withAuthenticationServer(props.getProperty("api.oauth.server.url"))
                 .build();
         return new EslClient(authTokenConfig, props.getProperty("api.url"), true, proxyConfiguration, true, additionalHeaders);

--- a/sdk/src/main/java/com/silanis/esl/sdk/examples/SDKSample.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/examples/SDKSample.java
@@ -32,7 +32,7 @@ public abstract class SDKSample {
     public int proxyPort, proxyWithCredentialsPort;
 
     public SDKSample() {
-        setupEslClientFromProps(Collections.<String, String>emptyMap(), null);
+        eslClient = setupEslClientFromProps(Collections.<String, String>emptyMap(), null);
         setProperties();
     }
 


### PR DESCRIPTION
…d when load tthe eslClient from a properties file the new EslClient was not assigned from the setClientFromProperties resulting in a Null pointer exception