### PR TITLE
feat/PB-105508 Oauth2 token requests accepts grant_type as form parameter

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/sdk/internal/RestClient.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/internal/RestClient.java
@@ -271,11 +271,15 @@ public class RestClient extends Client {
 
     private String getOAuth2BearerToken(OAuthTokenConfig oauthTokenConfig) throws IOException, RequestException {
         if (oAuthAccessToken == null || oauth2TokenManager.isOAuth2TokenExpired(oAuthAccessToken.getAccessToken())) {
-            HttpPost request = withUserAgent(new HttpPost(oauthTokenConfig.getAuthenticationURL()));
+            HttpPost request = withUserAgent(new HttpPost(oauthTokenConfig.getAuthenticationServer()));
             request.setHeader(
                 "Authorization",
                 "Basic " + Base64.getEncoder().encodeToString(String.format("%s:%s", oauthTokenConfig.getClientId(),
                     oauthTokenConfig.getClientSecret()).getBytes()));
+
+            request.addHeader(HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
+            request.setEntity(new StringEntity("grant_type=client_credentials", ContentType.create(HEADER_CONTENT_TYPE,
+                Consts.UTF_8)));
 
             CloseableHttpClient client = getHttpClient(request);
             HttpResponse httpResponse = client.execute(request);

--- a/sdk/src/main/java/com/silanis/esl/sdk/oauth/OAuthTokenConfig.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/oauth/OAuthTokenConfig.java
@@ -19,10 +19,6 @@ public class OAuthTokenConfig {
         return new Builder();
     }
 
-    public String getAuthenticationURL() {
-        return String.format("%s?grant_type=%s", getAuthenticationServer(), getGrantType());
-    }
-
     public String getClientId() {
         return clientId;
     }


### PR DESCRIPTION
Following the bug fix in 'spring-security-authorization-server' release 0.4.5, the authorization server will not accept grant_type in QueryParam. 