### PR TITLE
feat: PB-126494 add forceUpdateDocumentMetadata to Java SDK

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/sdk/examples/DocumentOperationsExample.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/examples/DocumentOperationsExample.java
@@ -5,6 +5,9 @@ import com.silanis.esl.sdk.DocumentPackage;
 import com.silanis.esl.sdk.DocumentType;
 import com.silanis.esl.sdk.builder.FieldBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static com.silanis.esl.sdk.builder.DocumentBuilder.newDocumentWithName;
 import static com.silanis.esl.sdk.builder.PackageBuilder.newPackageNamed;
 import static com.silanis.esl.sdk.builder.SignatureBuilder.signatureFor;
@@ -75,6 +78,13 @@ public class DocumentOperationsExample extends SDKSample {
         eslClient.getPackageService().updateDocumentMetadata(retrievedPackage, document);
         retrievedUpdatedDocument = eslClient.getPackageService().getDocumentMetadata(retrievedPackage, document.getId().getId());
         retrievedPackageWithUpdatedDocument = eslClient.getPackage(packageId);
+
+        //This is how you would force-update a document's custom metadata (its data map) regardless of
+        //the transaction's status. Requires the account's manipulateMetadata feature to be enabled.
+        Map<String, Object> metadata = new HashMap<String, Object>();
+        metadata.put("customerId", "12345");
+        document.setData(metadata);
+        eslClient.getPackageService().forceUpdateDocumentMetadata(retrievedPackage, document);
 
         //This is how you would delete a document from a package
         eslClient.getPackageService().deleteDocument(packageId, document.getId().toString());

--- a/sdk/src/main/java/com/silanis/esl/sdk/internal/UrlTemplate.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/internal/UrlTemplate.java
@@ -22,6 +22,7 @@ public class UrlTemplate {
     public static final String DOCUMENT_PATH = "/packages/{packageId}/documents";
     public static final String DOCUMENT_VISIBILITY_PATH = "/packages/{packageId}/documents/visibility";
     public static final String DOCUMENT_ID_PATH = "/packages/{packageId}/documents/{documentId}";
+    public static final String DOCUMENT_METADATA_PATH = "/packages/{packageId}/documents/{documentId}/metadata";
     public static final String ROLE_PATH = "/packages/{packageId}/roles";
     public static final String ROLE_ID_PATH = "/packages/{packageId}/roles/{roleId}";
     public static final String ROLE_UNLOCK_PATH = "/packages/{packageId}/roles/{roleId}/unlock";

--- a/sdk/src/main/java/com/silanis/esl/sdk/service/PackageService.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/service/PackageService.java
@@ -684,6 +684,35 @@ public class PackageService extends EslComponent {
     }
 
     /**
+     * Updates the document's metadata (its data map) via the dedicated metadata endpoint, which
+     * applies regardless of the transaction's status when the account's manipulateMetadata feature
+     * is enabled.
+     *
+     * @param documentPackage the package containing the document
+     * @param document the document whose data map to send
+     */
+    public void forceUpdateDocumentMetadata(DocumentPackage documentPackage, com.silanis.esl.sdk.Document document) {
+        String path = new UrlTemplate(getBaseUrl()).urlFor(UrlTemplate.DOCUMENT_METADATA_PATH)
+                .replace(PACKAGE_ID_PATH_PARAM, documentPackage.getId().getId())
+                .replace("{documentId}", document.getId().toString())
+                .build();
+
+        // The /metadata endpoint reads the whole request body as the document's data map.
+        // Send the bare data map, not a serialized Document.
+        Map<String, Object> metadata = document.getData() != null ? document.getData() : new HashMap<>();
+
+        try {
+            String json = JacksonUtil.serialize(metadata);
+
+            getClient().put(path, json);
+        } catch (RequestException e) {
+            throw new EslServerException("Could not update the document's metadata.", e);
+        } catch (Exception e) {
+            throw new EslException("Could not update the document's metadata." + " Exception: " + e.getMessage());
+        }
+    }
+
+    /**
      * Localizes the default consent document for the specified package and language.
      * <p>
      * This method sends a localization request for the default consent document of the given package using the provided language and returns

--- a/sdk/src/test/java/com/silanis/esl/sdk/PackageServiceTest.java
+++ b/sdk/src/test/java/com/silanis/esl/sdk/PackageServiceTest.java
@@ -586,6 +586,46 @@ public class PackageServiceTest {
         assertNull(result.getConsentInfo().getConsentData());
     }
 
+    @Test
+    public void testForceUpdateDocumentMetadataPutsBareDataMapToMetadataEndpoint() throws Exception {
+        String packageUid = "pkg1";
+        String documentId = "doc1";
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("customerId", "12345");
+
+        DocumentPackage documentPackage = PackageBuilder.newPackageNamed("Test Package")
+                .withDocument(DocumentBuilder.newDocumentWithName("Test Document")
+                        .withId(documentId)
+                        .withData(data))
+                .build();
+        documentPackage.setId(new PackageId(packageUid));
+
+        String expectedPath = new UrlTemplate("http://baseurl").urlFor(UrlTemplate.DOCUMENT_METADATA_PATH)
+                .replace("{packageId}", packageUid)
+                .replace("{documentId}", documentId)
+                .build();
+
+        packageService.forceUpdateDocumentMetadata(documentPackage, documentPackage.getDocument("Test Document"));
+
+        // Body is the bare data map, not a serialized Document (no "data"/"name" wrapper).
+        verify(clientMock).put(eq(expectedPath), eq("{\"customerId\":\"12345\"}"));
+    }
+
+    @Test(expected = EslServerException.class)
+    public void testForceUpdateDocumentMetadataWrapsRequestExceptionAsServerException() throws Exception {
+        DocumentPackage documentPackage = PackageBuilder.newPackageNamed("Test Package")
+                .withDocument(DocumentBuilder.newDocumentWithName("Test Document")
+                        .withId("doc1")
+                        .withData(new HashMap<String, Object>()))
+                .build();
+        documentPackage.setId(new PackageId("pkg1"));
+
+        when(clientMock.put(anyString(), anyString()))
+                .thenThrow(new RequestException("PUT", "uri", 500, "Server Error", "{}"));
+
+        packageService.forceUpdateDocumentMetadata(documentPackage, documentPackage.getDocument("Test Document"));
+    }
+
     private String toApiPackageJson(String packageUid, String language) {
         Package apiPackage = getAPackage(packageUid, language);
         return Serialization.toJson(apiPackage);


### PR DESCRIPTION
## What does this PR do

- Adds `forceUpdateDocumentMetadata(DocumentPackage, Document)` to `PackageService`, updating a document's custom metadata (its `data` map) regardless of the transaction's status.
- Sends only the metadata map to the dedicated `PUT .../documents/{documentId}/metadata` endpoint, which the backend applies when the account's `manipulateMetadata` feature is enabled.
- Leaves the existing `updateDocumentMetadata` untouched: it still updates descriptive fields via the editable-only document endpoint.
- Demonstrates the new method in `DocumentOperationsExample`.

## Why are we doing this

- Integrators need to attach or change custom information on a document after the transaction is completed. The existing metadata call cannot do this: the backend blocks it once the transaction is no longer editable.

Ticket: PB-126494
