### PR TITLE
feat: PB-130297 add SDK support for updating transaction metadata regardless of status

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/sdk/examples/ForceUpdatePackageMetadataExample.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/examples/ForceUpdatePackageMetadataExample.java
@@ -1,0 +1,72 @@
+package com.silanis.esl.sdk.examples;
+
+import com.silanis.esl.sdk.Document;
+import com.silanis.esl.sdk.DocumentPackage;
+import com.silanis.esl.sdk.DocumentPackageAttributes;
+import com.silanis.esl.sdk.DocumentType;
+
+import static com.silanis.esl.sdk.builder.DocumentBuilder.newDocumentWithName;
+import static com.silanis.esl.sdk.builder.PackageBuilder.newPackageNamed;
+import static com.silanis.esl.sdk.builder.SignatureBuilder.signatureFor;
+import static com.silanis.esl.sdk.builder.SignerBuilder.newSignerWithEmail;
+
+/**
+ * End-to-end check for {@code forceUpdatePackageMetadata} (PB-130297).
+ * <p>
+ * Prerequisite: the account behind {@code api.key} must have the {@code manipulateMetadata}
+ * feature enabled. Without it the force call fails with a validation error
+ * ({@code manipulateMetadata.featureDisabled}).
+ * <p>
+ * The transaction is created and SENT so it is no longer editable, then the example shows that
+ * {@code forceUpdatePackageMetadata} updates the transaction's own custom metadata (its attributes)
+ * regardless of the transaction's status.
+ * <p>
+ * Run: fill {@code signers.properties} (webpage.url, api.key, 1.email) on the classpath, then run
+ * this class's {@code main}.
+ */
+public class ForceUpdatePackageMetadataExample extends SDKSample {
+
+    public static void main(String... args) {
+        new ForceUpdatePackageMetadataExample().run();
+    }
+
+    @Override
+    public void execute() {
+        // 1. Create a package with one signer, upload a signable document, then SEND it so it is no
+        //    longer editable.
+        DocumentPackage builtPackage = newPackageNamed(getPackageName())
+                .describedAs("forceUpdatePackageMetadata smoke test")
+                .withSigner(newSignerWithEmail(email1)
+                        .withFirstName("John")
+                        .withLastName("Smith"))
+                .build();
+
+        packageId = eslClient.createPackage(builtPackage);
+
+        Document document = newDocumentWithName("Contract")
+                .fromStream(documentInputStream1, DocumentType.PDF)
+                .withSignature(signatureFor(email1)
+                        .onPage(0)
+                        .atPosition(100, 100))
+                .build();
+        eslClient.uploadDocument(document, packageId);
+
+        eslClient.sendPackage(packageId);
+        System.out.println("Sent transaction " + packageId.getId() + " (status is now SENT, no longer editable).");
+
+        // 2. Reload the sent transaction and force-update its custom metadata (transaction attributes).
+        DocumentPackage sent = eslClient.getPackage(packageId);
+
+        DocumentPackageAttributes attributes = new DocumentPackageAttributes();
+        attributes.append("customerId", "12345");
+        attributes.append("region", "EMEA");
+        sent.setAttributes(attributes);
+
+        eslClient.getPackageService().forceUpdatePackageMetadata(sent);
+        System.out.println("forceUpdatePackageMetadata succeeded on a SENT transaction.");
+
+        // 3. Read the metadata back and confirm the force-update was applied.
+        DocumentPackage reloaded = eslClient.getPackage(packageId);
+        System.out.println("Transaction metadata after force-update: " + reloaded.getAttributes().toMap());
+    }
+}

--- a/sdk/src/main/java/com/silanis/esl/sdk/internal/UrlTemplate.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/internal/UrlTemplate.java
@@ -17,6 +17,7 @@ public class UrlTemplate {
     public static final String PACKAGE_FIELDS_LIST_PATH = "/packages?query={status}&from={from}&to={to}&fields={fields}";
     public static final String PACKAGE_LIST_STATUS_DATE_RANGE_PATH = "/packages?query={status}&from={from}&to={to}&startDate={lastUpdatedStartDate}&endDate={lastUpdatedEndDate}";
     public static final String PACKAGE_ID_PATH = "/packages/{packageId}";
+    public static final String PACKAGE_METADATA_PATH = "/packages/{packageId}/metadata";
     public static final String PACKAGE_ID_WITH_EXTENSIONS_PATH = "/packages/{packageId}?extensions={extensions}";
     public static final String PACKAGE_REFERENCED_CONDITIONS_PATH = "/packages/{packageId}/referencedConditions";
     public static final String DOCUMENT_PATH = "/packages/{packageId}/documents";

--- a/sdk/src/main/java/com/silanis/esl/sdk/service/PackageService.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/service/PackageService.java
@@ -713,6 +713,35 @@ public class PackageService extends EslComponent {
     }
 
     /**
+     * Updates the transaction's (package's) custom metadata — its attributes/data map — via the
+     * dedicated package metadata endpoint, which applies regardless of the transaction's status when
+     * the account's manipulateMetadata feature is enabled.
+     *
+     * @param documentPackage the package (transaction) whose attributes map to send
+     */
+    public void forceUpdatePackageMetadata(DocumentPackage documentPackage) {
+        String path = new UrlTemplate(getBaseUrl()).urlFor(UrlTemplate.PACKAGE_METADATA_PATH)
+                .replace(PACKAGE_ID_PATH_PARAM, documentPackage.getId().getId())
+                .build();
+
+        // The /metadata endpoint reads the whole request body as the transaction's data map.
+        // Send the bare data map, not a serialized Package.
+        Map<String, Object> metadata = documentPackage.getAttributes() != null
+                ? documentPackage.getAttributes().toMap()
+                : new HashMap<>();
+
+        try {
+            String json = JacksonUtil.serialize(metadata);
+
+            getClient().put(path, json);
+        } catch (RequestException e) {
+            throw new EslServerException("Could not update the package's metadata.", e);
+        } catch (Exception e) {
+            throw new EslException("Could not update the package's metadata." + " Exception: " + e.getMessage());
+        }
+    }
+
+    /**
      * Localizes the default consent document for the specified package and language.
      * <p>
      * This method sends a localization request for the default consent document of the given package using the provided language and returns

--- a/sdk/src/test/java/com/silanis/esl/sdk/PackageServiceTest.java
+++ b/sdk/src/test/java/com/silanis/esl/sdk/PackageServiceTest.java
@@ -626,6 +626,39 @@ public class PackageServiceTest {
         packageService.forceUpdateDocumentMetadata(documentPackage, documentPackage.getDocument("Test Document"));
     }
 
+    @Test
+    public void testForceUpdatePackageMetadataPutsBareDataMapToMetadataEndpoint() throws Exception {
+        String packageUid = "pkg1";
+
+        DocumentPackageAttributes attributes = new DocumentPackageAttributes();
+        attributes.append("customerId", "12345");
+
+        DocumentPackage documentPackage = PackageBuilder.newPackageNamed("Test Package").build();
+        documentPackage.setId(new PackageId(packageUid));
+        documentPackage.setAttributes(attributes);
+
+        String expectedPath = new UrlTemplate("http://baseurl").urlFor(UrlTemplate.PACKAGE_METADATA_PATH)
+                .replace("{packageId}", packageUid)
+                .build();
+
+        packageService.forceUpdatePackageMetadata(documentPackage);
+
+        // Body is the bare attributes map, not a serialized Package (no "data"/"name" wrapper).
+        verify(clientMock).put(eq(expectedPath), eq("{\"customerId\":\"12345\"}"));
+    }
+
+    @Test(expected = EslServerException.class)
+    public void testForceUpdatePackageMetadataWrapsRequestExceptionAsServerException() throws Exception {
+        DocumentPackage documentPackage = PackageBuilder.newPackageNamed("Test Package").build();
+        documentPackage.setId(new PackageId("pkg1"));
+        documentPackage.setAttributes(new DocumentPackageAttributes());
+
+        when(clientMock.put(anyString(), anyString()))
+                .thenThrow(new RequestException("PUT", "uri", 500, "Server Error", "{}"));
+
+        packageService.forceUpdatePackageMetadata(documentPackage);
+    }
+
     private String toApiPackageJson(String packageUid, String language) {
         Package apiPackage = getAPackage(packageUid, language);
         return Serialization.toJson(apiPackage);


### PR DESCRIPTION
## PB-130297 — Add SDK support for modifying transaction metadata regardless of status

Adds SDK support for updating a **transaction's (package's) custom metadata regardless of its status**, when the account's `manipulateMetadata` feature is enabled. This is the package-scoped analogue of the existing `forceUpdateDocumentMetadata` (PB-126494).

### Changes
- `PackageService.forceUpdatePackageMetadata(DocumentPackage)` — serializes the transaction's bare attributes map and `PUT`s it to `/packages/{packageId}/metadata` (the status-agnostic, feature-gated endpoint). Mirrors `forceUpdateDocumentMetadata`.
- New `UrlTemplate.PACKAGE_METADATA_PATH` constant.
- Unit tests: bare-map body sent to the metadata endpoint + server-error wrapping.
- `ForceUpdatePackageMetadataExample` end-to-end sample (documents the `manipulateMetadata` prerequisite).

### Testing
`mvn -pl sdk test -Dtest=PackageServiceTest` → **21 passed, 0 failed**.

Generated with Claude Code
