### PR TITLE
feat: PB-130298 add SDK support for updating role metadata regardless of status

### DIFF
--- a/sdk/src/main/java/com/silanis/esl/sdk/Signer.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/Signer.java
@@ -3,6 +3,7 @@ package com.silanis.esl.sdk;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * <p>The Signer class contains all the information about an user that is supposed to sign a document.</p>
@@ -35,6 +36,7 @@ public class Signer implements Serializable {
     private boolean newPlaceholderSigner;
     private Boolean specifier;
     private boolean carbonCopyRecipient;
+    private Map<String, Object> data;
 
     /**
      * <p>The constructor of the Signer class.</p> 
@@ -345,6 +347,26 @@ public class Signer implements Serializable {
 
     public GroupId getGroupId() {
         return this.groupId;
+    }
+
+    /**
+     * Accessor method used to retrieve the role's (signer's) custom metadata map.
+     *
+     * @return the role's metadata map, or null if none has been set
+     */
+    public Map<String, Object> getData() {
+        return data;
+    }
+
+    /**
+     * Sets the role's (signer's) custom metadata map. Used with
+     * {@code PackageService.forceUpdateRoleMetadata} to update role metadata via the dedicated
+     * metadata endpoint regardless of the transaction's status.
+     *
+     * @param data the role's metadata map
+     */
+    public void setData(Map<String, Object> data) {
+        this.data = data;
     }
 
     public String getPlaceholderName() {

--- a/sdk/src/main/java/com/silanis/esl/sdk/examples/ForceUpdateRoleMetadataExample.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/examples/ForceUpdateRoleMetadataExample.java
@@ -1,0 +1,77 @@
+package com.silanis.esl.sdk.examples;
+
+import com.silanis.esl.sdk.Document;
+import com.silanis.esl.sdk.DocumentPackage;
+import com.silanis.esl.sdk.DocumentType;
+import com.silanis.esl.sdk.Signer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.silanis.esl.sdk.builder.DocumentBuilder.newDocumentWithName;
+import static com.silanis.esl.sdk.builder.PackageBuilder.newPackageNamed;
+import static com.silanis.esl.sdk.builder.SignatureBuilder.signatureFor;
+import static com.silanis.esl.sdk.builder.SignerBuilder.newSignerWithEmail;
+
+/**
+ * End-to-end check for {@code forceUpdateRoleMetadata} (PB-130298).
+ * <p>
+ * Prerequisite: the account behind {@code api.key} must have the {@code manipulateMetadata}
+ * feature enabled. Without it the force call fails with a validation error
+ * ({@code manipulateMetadata.featureDisabled}).
+ * <p>
+ * The transaction is created and SENT so it is no longer editable, then the example shows that
+ * {@code forceUpdateRoleMetadata} updates a role's (signer's) custom metadata regardless of the
+ * transaction's status. The role metadata endpoint replaces the role's data map with the one
+ * supplied on the signer.
+ * <p>
+ * Run: fill {@code signers.properties} (webpage.url, api.key, 1.email) on the classpath, then run
+ * this class's {@code main}.
+ */
+public class ForceUpdateRoleMetadataExample extends SDKSample {
+
+    public static void main(String... args) {
+        new ForceUpdateRoleMetadataExample().run();
+    }
+
+    @Override
+    public void execute() {
+        // 1. Create a package with one signer, upload a signable document, then SEND it so it is no
+        //    longer editable.
+        DocumentPackage builtPackage = newPackageNamed(getPackageName())
+                .describedAs("forceUpdateRoleMetadata smoke test")
+                .withSigner(newSignerWithEmail(email1)
+                        .withFirstName("John")
+                        .withLastName("Smith"))
+                .build();
+
+        packageId = eslClient.createPackage(builtPackage);
+
+        Document document = newDocumentWithName("Contract")
+                .fromStream(documentInputStream1, DocumentType.PDF)
+                .withSignature(signatureFor(email1)
+                        .onPage(0)
+                        .atPosition(100, 100))
+                .build();
+        eslClient.uploadDocument(document, packageId);
+
+        eslClient.sendPackage(packageId);
+        System.out.println("Sent transaction " + packageId.getId() + " (status is now SENT, no longer editable).");
+
+        // 2. Reload the sent transaction, grab the role (signer), and force-update its custom metadata.
+        DocumentPackage sent = eslClient.getPackage(packageId);
+        Signer signer = sent.getSigner(email1);
+
+        Map<String, Object> metadata = new HashMap<String, Object>();
+        metadata.put("customerId", "12345");
+        metadata.put("region", "EMEA");
+        signer.setData(metadata);
+
+        eslClient.getPackageService().forceUpdateRoleMetadata(sent, signer);
+        System.out.println("forceUpdateRoleMetadata succeeded on a SENT transaction.");
+
+        // 3. Read the metadata back and confirm the force-update was applied.
+        DocumentPackage reloaded = eslClient.getPackage(packageId);
+        System.out.println("Role metadata after force-update: " + reloaded.getSigner(email1).getData());
+    }
+}

--- a/sdk/src/main/java/com/silanis/esl/sdk/internal/UrlTemplate.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/internal/UrlTemplate.java
@@ -26,6 +26,7 @@ public class UrlTemplate {
     public static final String DOCUMENT_METADATA_PATH = "/packages/{packageId}/documents/{documentId}/metadata";
     public static final String ROLE_PATH = "/packages/{packageId}/roles";
     public static final String ROLE_ID_PATH = "/packages/{packageId}/roles/{roleId}";
+    public static final String ROLE_METADATA_PATH = "/packages/{packageId}/roles/{roleId}/metadata";
     public static final String ROLE_UNLOCK_PATH = "/packages/{packageId}/roles/{roleId}/unlock";
     public static final String PDF_PATH = "/packages/{packageId}/documents/{documentId}/pdf";
     public static final String ORIGINAL_PATH = "/packages/{packageId}/documents/{documentId}/original";

--- a/sdk/src/main/java/com/silanis/esl/sdk/internal/converter/SignerConverter.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/internal/converter/SignerConverter.java
@@ -15,6 +15,7 @@ import com.silanis.esl.sdk.builder.SignerBuilder;
 import com.silanis.esl.sdk.internal.Asserts;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -170,6 +171,9 @@ public class SignerConverter {
             if (localLanguage != null) {
                 signer.setLocalLanguage(localLanguage.toString());
             }
+        }
+        if (apiRoleData != null) {
+            signer.setData(new HashMap<String, Object>(apiRoleData));
         }
 
         return signer;

--- a/sdk/src/main/java/com/silanis/esl/sdk/service/PackageService.java
+++ b/sdk/src/main/java/com/silanis/esl/sdk/service/PackageService.java
@@ -742,6 +742,36 @@ public class PackageService extends EslComponent {
     }
 
     /**
+     * Updates the role's (signer's) metadata — its data map — via the dedicated role metadata
+     * endpoint, which applies regardless of the transaction's status when the account's
+     * manipulateMetadata feature is enabled. The endpoint replaces the role's data map with the one
+     * supplied on the signer.
+     *
+     * @param documentPackage the package (transaction) containing the role
+     * @param signer the role (signer) whose data map to send
+     */
+    public void forceUpdateRoleMetadata(DocumentPackage documentPackage, com.silanis.esl.sdk.Signer signer) {
+        String path = new UrlTemplate(getBaseUrl()).urlFor(UrlTemplate.ROLE_METADATA_PATH)
+                .replace(PACKAGE_ID_PATH_PARAM, documentPackage.getId().getId())
+                .replace("{roleId}", signer.getId())
+                .build();
+
+        // The /metadata endpoint reads the whole request body as the role's data map.
+        // Send the bare data map, not a serialized Role.
+        Map<String, Object> metadata = signer.getData() != null ? signer.getData() : new HashMap<>();
+
+        try {
+            String json = JacksonUtil.serialize(metadata);
+
+            getClient().put(path, json);
+        } catch (RequestException e) {
+            throw new EslServerException("Could not update the role's metadata.", e);
+        } catch (Exception e) {
+            throw new EslException("Could not update the role's metadata." + " Exception: " + e.getMessage());
+        }
+    }
+
+    /**
      * Localizes the default consent document for the specified package and language.
      * <p>
      * This method sends a localization request for the default consent document of the given package using the provided language and returns

--- a/sdk/src/test/java/com/silanis/esl/sdk/PackageServiceTest.java
+++ b/sdk/src/test/java/com/silanis/esl/sdk/PackageServiceTest.java
@@ -659,6 +659,53 @@ public class PackageServiceTest {
         packageService.forceUpdatePackageMetadata(documentPackage);
     }
 
+    @Test
+    public void testForceUpdateRoleMetadataPutsBareDataMapToMetadataEndpoint() throws Exception {
+        String packageUid = "pkg1";
+        String roleId = "role1";
+
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("customerId", "12345");
+
+        Signer signer = SignerBuilder.newSignerWithEmail("john@example.com")
+                .withFirstName("John")
+                .withLastName("Smith")
+                .build();
+        signer.setId(roleId);
+        signer.setData(data);
+
+        DocumentPackage documentPackage = PackageBuilder.newPackageNamed("Test Package").build();
+        documentPackage.setId(new PackageId(packageUid));
+
+        String expectedPath = new UrlTemplate("http://baseurl").urlFor(UrlTemplate.ROLE_METADATA_PATH)
+                .replace("{packageId}", packageUid)
+                .replace("{roleId}", roleId)
+                .build();
+
+        packageService.forceUpdateRoleMetadata(documentPackage, signer);
+
+        // Body is the bare data map, not a serialized Role (no "data"/"name" wrapper).
+        verify(clientMock).put(eq(expectedPath), eq("{\"customerId\":\"12345\"}"));
+    }
+
+    @Test(expected = EslServerException.class)
+    public void testForceUpdateRoleMetadataWrapsRequestExceptionAsServerException() throws Exception {
+        Signer signer = SignerBuilder.newSignerWithEmail("john@example.com")
+                .withFirstName("John")
+                .withLastName("Smith")
+                .build();
+        signer.setId("role1");
+        signer.setData(new HashMap<String, Object>());
+
+        DocumentPackage documentPackage = PackageBuilder.newPackageNamed("Test Package").build();
+        documentPackage.setId(new PackageId("pkg1"));
+
+        when(clientMock.put(anyString(), anyString()))
+                .thenThrow(new RequestException("PUT", "uri", 500, "Server Error", "{}"));
+
+        packageService.forceUpdateRoleMetadata(documentPackage, signer);
+    }
+
     private String toApiPackageJson(String packageUid, String language) {
         Package apiPackage = getAPackage(packageUid, language);
         return Serialization.toJson(apiPackage);


### PR DESCRIPTION
## PB-130298 — Add SDK support for modifying role metadata regardless of status

Adds SDK support for updating a **role's (signer's) custom metadata regardless of the transaction's status**, when the account's `manipulateMetadata` feature is enabled. This is the role-scoped analog of `forceUpdatePackageMetadata` (PB-130297) and `forceUpdateDocumentMetadata` (PB-126494).

### Changes
- `PackageService.forceUpdateRoleMetadata(DocumentPackage, Signer)` — serializes the role's bare data map and `PUT`s it to `/packages/{packageId}/roles/{roleId}/metadata` (the status-agnostic, feature-gated endpoint, which replaces the role's data map).
- Adds a `data` map to the `Signer` model (get/set); `SignerConverter` now populates it on read so callers can set and read back role metadata.
- New `UrlTemplate.ROLE_METADATA_PATH` constant.
- Unit tests: bare-map body sent to the role metadata endpoint + server-error wrapping; existing `SignerConverterTest` still green (no regression).
- `ForceUpdateRoleMetadataExample` end-to-end sample (documents the `manipulateMetadata` prerequisite).

### Testing
- `mvn -pl sdk test -Dtest=PackageServiceTest,SignerConverterTest` → **40 passed, 0 failed**.
- Live end-to-end against OSSQ3 (feature enabled): created + sent a transaction, `forceUpdateRoleMetadata` succeeded on the SENT (non-editable) transaction, metadata read back as `{customerId=12345, region=EMEA}`.

Generated with Claude Code
